### PR TITLE
Use Float instead of Int for Heatmap Thresholds

### DIFF
--- a/src/terraform-provider-signalform/signalform/heatmap_chart.go
+++ b/src/terraform-provider-signalform/signalform/heatmap_chart.go
@@ -132,7 +132,7 @@ func heatmapChartResource() *schema.Resource {
 						"thresholds": &schema.Schema{
 							Type:        schema.TypeList,
 							Required:    true,
-							Elem:        &schema.Schema{Type: schema.TypeInt},
+							Elem:        &schema.Schema{Type: schema.TypeFloat},
 							MaxItems:    4,
 							Description: "The thresholds to set for the color range being used. Values (at most 4) must be in descending order",
 						},

--- a/src/terraform-provider-signalform/signalform/single_value_chart.go
+++ b/src/terraform-provider-signalform/signalform/single_value_chart.go
@@ -93,7 +93,7 @@ func singleValueChartResource() *schema.Resource {
 						"thresholds": &schema.Schema{
 							Type:        schema.TypeList,
 							Required:    true,
-							Elem:        &schema.Schema{Type: schema.TypeInt},
+							Elem:        &schema.Schema{Type: schema.TypeFloat},
 							MaxItems:    4,
 							Description: "The thresholds to set for the color range being used. Values (at most 4) must be in descending order",
 						},

--- a/src/terraform-provider-signalform/signalform/util.go
+++ b/src/terraform-provider-signalform/signalform/util.go
@@ -79,11 +79,11 @@ func getColorScaleOptions(d *schema.ResourceData) map[string]interface{} {
 	options := colorScale[0].(map[string]interface{})
 
 	thresholdsList := options["thresholds"].([]interface{})
-	thresholds := make([]float, len(thresholdsList))
+	thresholds := make([]float64, len(thresholdsList))
 	for i := range thresholdsList {
-		thresholds[i] = thresholdsList[i].(float)
+		thresholds[i] = thresholdsList[i].(float64)
 	}
-	sort.Sort(sort.Reverse(sort.IntSlice(thresholds)))
+	sort.Sort(sort.Reverse(sort.Float64Slice(thresholds)))
 	item["thresholds"] = thresholds
 	item["inverted"] = options["inverted"].(bool)
 	return item

--- a/src/terraform-provider-signalform/signalform/util.go
+++ b/src/terraform-provider-signalform/signalform/util.go
@@ -79,9 +79,9 @@ func getColorScaleOptions(d *schema.ResourceData) map[string]interface{} {
 	options := colorScale[0].(map[string]interface{})
 
 	thresholdsList := options["thresholds"].([]interface{})
-	thresholds := make([]int, len(thresholdsList))
+	thresholds := make([]float, len(thresholdsList))
 	for i := range thresholdsList {
-		thresholds[i] = thresholdsList[i].(int)
+		thresholds[i] = thresholdsList[i].(float)
 	}
 	sort.Sort(sort.Reverse(sort.IntSlice(thresholds)))
 	item["thresholds"] = thresholds


### PR DESCRIPTION
Per https://developers.signalfx.com/reference#section-colorscale ,
Heatmap thresholds can be specified as a Double. Since there is no
schema.TypeDouble, let's use a schema.TypeFloat instead.