### PR TITLE
Support new parameters in detector and rule model.

### DIFF
--- a/docs/resources/detector.md
+++ b/docs/resources/detector.md
@@ -50,11 +50,15 @@ variable "clusters" {
 * `time_range` - (Optional) From when to display data. SignalFx time syntax (e.g. `"-5m"`, `"-1h"`). Conflicts with `start_time` and `end_time`.
 * `start_time` - (Optional) Seconds since epoch. Used for visualization. Conflicts with `time_range`.
 * `end_time` - (Optional) Seconds since epoch. Used for visualization. Conflicts with `time_range`.
+* `tags` - (Optional) Tags associated with the detector.
+* `teams` - (Optional) Team IDs to associcate the detector to.
 * `rule` - (Required) Set of rules used for alerting.
     * `detect_label` - (Required) A detect label which matches a detect label within `program_text`.
     * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Warning"`, `"Major"`, `"Minor"`, `"Info"`.
     * `disabled` - (Optional) When true, notifications and events will not be generated for the detect label. `false` by default.
     * `notifications` - (Optional) List of strings specifying where notifications will be sent when an incident occurs. See <https://developers.signalfx.com/v2/docs/detector-model#notifications-models> for more info.
+    * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See https://developers.signalfx.com/v2/reference#detector-model for more info.
+    * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See https://d    evelopers.signalfx.com/v2/reference#detector-model for more info.
 
 **Notes**
 

--- a/src/terraform-provider-signalform/signalform/detector.go
+++ b/src/terraform-provider-signalform/signalform/detector.go
@@ -171,12 +171,12 @@ func getPayloadDetector(d *schema.ResourceData) ([]byte, error) {
 		item["detectLabel"] = tf_rule["detect_label"].(string)
 		item["disabled"] = tf_rule["disabled"].(bool)
 
-		if value, ok := tf_rule["parameterized_body"]; ok {
-			item["parameterizedBody"] = value
+		if val, ok := tf_rule["parameterized_body"]; ok {
+			item["parameterizedBody"] = val.(string)
 		}
 
-		if value, ok := tf_rule["parameterized_subject"]; ok {
-			item["parameterizedSubject"] = value
+		if val, ok := tf_rule["parameterized_subject"]; ok {
+			item["parameterizedSubject"] = val.(string)
 		}
 
 		if notifications, ok := tf_rule["notifications"]; ok {
@@ -201,6 +201,14 @@ func getPayloadDetector(d *schema.ResourceData) ([]byte, error) {
 
 	if viz := getVisualizationOptionsDetector(d); len(viz) > 0 {
 		payload["visualizationOptions"] = viz
+	}
+
+	if val, ok := d.GetOk("teams"); ok {
+		payload["teams"] = val
+	}
+
+	if val, ok := d.GetOk("tags"); ok {
+		payload["tags"] = val
 	}
 
 	return json.Marshal(payload)
@@ -302,6 +310,14 @@ func resourceRuleHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["severity"]))
 	buf.WriteString(fmt.Sprintf("%s-", m["detect_label"]))
 	buf.WriteString(fmt.Sprintf("%s-", m["disabled"]))
+
+	if val, ok := m["parameterized_body"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", val))
+	}
+
+	if val, ok := m["parameterized_subject"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", val))
+	}
 
 	// Sort the notifications so that we generate a consistent hash
 	if v, ok := m["notifications"]; ok {

--- a/src/terraform-provider-signalform/signalform/detector.go
+++ b/src/terraform-provider-signalform/signalform/detector.go
@@ -86,6 +86,18 @@ func detectorResource() *schema.Resource {
 				ConflictsWith: []string{"time_range"},
 				Description:   "Seconds since epoch. Used for visualization",
 			},
+			"tags": &schema.Schema{
+				Type:	       schema.TypeList,
+				Optional:      true,
+				Elem:	       &schema.Schema{Type: schema.TypeString},
+				Description:   "Tags associated with the detector",
+			},
+			"teams": &schema.Schema{
+				Type:	       schema.TypeList,
+				Optional:      true,
+				Elem:	       &schema.Schema{Type: schema.TypeString},
+				Description:   "Team IDs to associate the detector to",
+			},
 			"rule": &schema.Schema{
 				Type:        schema.TypeSet,
 				Required:    true,
@@ -120,6 +132,16 @@ func detectorResource() *schema.Resource {
 							Default:     false,
 							Description: "(default: false) When true, notifications and events will not be generated for the detect label",
 						},
+						"parameterized_body": &schema.Schema{
+							Type:	     schema.TypeString,
+							Optional:    true,
+							Description: "Custom notification message body when an alert is triggered. See https://developers.signalfx.com/v2/reference#detector-model for more info",
+						},
+						"parameterized_subject": &schema.Schema{
+							Type:	     schema.TypeString,
+							Optional:    true,
+							Description: "Custom notification message subject when an alert is triggered. See https://d    evelopers.signalfx.com/v2/reference#detector-model for more info",
+						},
 					},
 				},
 				Set: resourceRuleHash,
@@ -148,6 +170,14 @@ func getPayloadDetector(d *schema.ResourceData) ([]byte, error) {
 		item["severity"] = tf_rule["severity"].(string)
 		item["detectLabel"] = tf_rule["detect_label"].(string)
 		item["disabled"] = tf_rule["disabled"].(bool)
+
+		if value, ok := tf_rule["parameterized_body"]; ok {
+			item["parameterizedBody"] = value
+		}
+
+		if value, ok := tf_rule["parameterized_subject"]; ok {
+			item["parameterizedSubject"] = value
+		}
 
 		if notifications, ok := tf_rule["notifications"]; ok {
 			notify := getNotifications(notifications.([]interface{}))

--- a/src/terraform-provider-signalform/signalform/detector.go
+++ b/src/terraform-provider-signalform/signalform/detector.go
@@ -204,11 +204,19 @@ func getPayloadDetector(d *schema.ResourceData) ([]byte, error) {
 	}
 
 	if val, ok := d.GetOk("teams"); ok {
-		payload["teams"] = val
+		teams := []string{}
+                for _, team := range val.([]interface{}) {
+			teams = append(teams, team.(string))
+                }
+                payload["teams"] = teams
 	}
 
 	if val, ok := d.GetOk("tags"); ok {
-		payload["tags"] = val
+		tags := []string{}
+		for _, tag := range val.([]interface{}) {
+			tags = append(tags, tag.(string))
+		}
+		payload["tags"] = tags
 	}
 
 	return json.Marshal(payload)

--- a/src/terraform-provider-signalform/signalform/detector_test.go
+++ b/src/terraform-provider-signalform/signalform/detector_test.go
@@ -42,6 +42,19 @@ func TestResourceRuleHash(t *testing.T) {
 
 	expected := hashcode.String("Test Rule Name-Critical-Test Detect Label-true-")
 	assert.Equal(t, expected, resourceRuleHash(values))
+
+	// Test new params in rules
+	values = map[string]interface{}{
+		"description":  "Test Rule Name",
+		"detect_label": "Test Detect Label",
+		"severity":     "Critical",
+		"disabled":     "true",
+		"parameterized_subject": "Test subject",
+		"parameterized_body": "Test body",
+	}
+
+	expected = hashcode.String("Test Rule Name-Critical-Test Detect Label-true-Test body-Test subject-")
+	assert.Equal(t, expected, resourceRuleHash(values))
 }
 
 func TestValidateSeverityAllowed(t *testing.T) {


### PR DESCRIPTION
SignalFx supports new parameters in their rules and detector
model. These parameters help in defining custom alert messages
and also support adding tags and team-ids to detector.

https://developers.signalfx.com/v2/reference#detector-model

**Testing**
`make test` passes.