### PR TITLE
Update detector model to use runbookUrl and tip params.

### DIFF
--- a/docs/resources/detector.md
+++ b/docs/resources/detector.md
@@ -60,7 +60,7 @@ variable "clusters" {
     * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See https://developers.signalfx.com/v2/reference#detector-model for more info.
     * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See https://developers.signalfx.com/v2/reference#detector-model for more info.
     * `runbook_url` - (Optional) URL of page to consult when an alert is triggered. This can be used with custom notification messages.
-    * `tip` - Plain text suggested first course of action, such as a command line to execute. This can be used with custom notification messages.
+    * `tip` - (Optional) Plain text suggested first course of action, such as a command line to execute. This can be used with custom notification messages.
 
 **Notes**
 

--- a/docs/resources/detector.md
+++ b/docs/resources/detector.md
@@ -58,7 +58,9 @@ variable "clusters" {
     * `disabled` - (Optional) When true, notifications and events will not be generated for the detect label. `false` by default.
     * `notifications` - (Optional) List of strings specifying where notifications will be sent when an incident occurs. See <https://developers.signalfx.com/v2/docs/detector-model#notifications-models> for more info.
     * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See https://developers.signalfx.com/v2/reference#detector-model for more info.
-    * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See https://d    evelopers.signalfx.com/v2/reference#detector-model for more info.
+    * `parameterized_subject` - (Optional) Custom notification message subject when an alert is triggered. See https://developers.signalfx.com/v2/reference#detector-model for more info.
+    * `runbook_url` - (Optional) URL of page to consult when an alert is triggered. This can be used with custom notification messages.
+    * `tip` - Plain text suggested first course of action, such as a command line to execute. This can be used with custom notification messages.
 
 **Notes**
 

--- a/src/terraform-provider-signalform/signalform/detector_test.go
+++ b/src/terraform-provider-signalform/signalform/detector_test.go
@@ -55,6 +55,20 @@ func TestResourceRuleHash(t *testing.T) {
 
 	expected = hashcode.String("Test Rule Name-Critical-Test Detect Label-true-Test body-Test subject-")
 	assert.Equal(t, expected, resourceRuleHash(values))
+
+	values = map[string]interface{}{
+		"description":  "Test Rule Name",
+		"detect_label": "Test Detect Label",
+		"severity":     "Critical",
+		"disabled":     "true",
+		"parameterized_subject": "Test subject",
+		"parameterized_body": "Test body",
+		"runbook_url": "https://example.com",
+		"tip": "test tip",
+	}
+
+	expected = hashcode.String("Test Rule Name-Critical-Test Detect Label-true-Test body-Test subject-https://example.com-test tip-")
+	assert.Equal(t, expected, resourceRuleHash(values))
 }
 
 func TestValidateSeverityAllowed(t *testing.T) {


### PR DESCRIPTION
**Summary**
Detector model now supports creation of detectors with runbookUrl and tip. For reference, see https://developers.signalfx.com/reference#detector-model. Added documentation and test case to ensure the changes work.

**Testing done**
`make test` passes.

