### PR TITLE
Signalform Add custom color range in heatmap charts

### DIFF
--- a/docs/resources/heatmap_chart.md
+++ b/docs/resources/heatmap_chart.md
@@ -44,7 +44,10 @@ The following arguments are supported in the resource block:
     * `min_value` - (Optional) The minimum value within the coloring range.
     * `max_value` - (Optional) The maximum value within the coloring range.
     * `color` - (Required) The color range to use. Must be either gray, blue, navy, orange, yellow, magenta, purple, violet, lilac, green, aquamarine. ![Colors](https://github.com/Yelp/terraform-provider-signalform/raw/master/docs/resources/colors.png)
-* `color_scale` - (Optional. Conflict with `color_range`) Values for each color in the range. Example: `{ thresholds : [ 80, 60, 40, 20, 0 ], inverted : true }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
-    * `thresholds` - (Required) The thresholds to set for the color range being used. Values (at most 4) must be in descending order.
-    * `inverted` - (Optional) If `false` or omitted, values are red if they are above the highest specified value. If `true`, values are red if they are below the lowest specified value. `false` by default.
+* `color_scale` - (Optional. Conflict with `color_range`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt : 60, color : blue }, { lte : 60, color : yellow }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+    * `gt` - (Optional) Indicates the lower threshold non-inclusive value for this range.
+    * `gte` - (Optional) Indicates the lower threshold inclusive value for this range.
+    * `lt` - (Optional) Indicates the upper threshold non-inculsive value for this range.
+    * `lte` - (Optional) Indicates the upper threshold inclusive value for this range.
+    * `color` - (Required) The color range to use. Must be either gray, blue, navy, orange, yellow, magenta, purple, violet, lilac, green, aquamarine. ![Colors](https://github.com/Yelp/terraform-provider-signalform/raw/master/docs/resources/colors.png)
 * `synced` - (Optional) Whether the resource in SignalForm and SignalFx are identical or not. Used internally for syncing, you do not need to specify it. Whenever you see a change to this field in the plan, it means that your resource has been changed from the UI and Terraform is now going to re-sync it back to what is in your configuration.

--- a/docs/resources/single_value_chart.md
+++ b/docs/resources/single_value_chart.md
@@ -38,9 +38,12 @@ The following arguments are supported in the resource block:
 * `program_text` - (Required) Signalflow program text for the chart. More info at <https://developers.signalfx.com/docs/signalflow-overview>.
 * `description` - (Optional) Description of the chart.
 * `color_by` - (Optional) Must be `"Dimension"` or `"Metric"`. `"Dimension"` by default.
-* `color_scale` - (Optional. `color_by` must be `"Scale"`) Values for each color in the range. Example: `{ thresholds : [ 80, 60, 40, 20, 0 ], inverted : true }`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
-    * `thresholds` - (Required) The thresholds to set for the color range being used. Values (at most `4`) must be in descending order.
-    * `inverted` - (Optional) If false or omitted, values are red if they are above the highest specified value. If `true`, values are red if they are below the lowest specified value. `false` by default.
+* `color_scale` - (Optional. `color_by` must be `"Scale"`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt : 60, color : blue }, { lte : 60, color : yellow }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+    * `gt` - (Optional) Indicates the lower threshold non-inclusive value for this range.
+    * `gte` - (Optional) Indicates the lower threshold inclusive value for this range.
+    * `lt` - (Optional) Indicates the upper threshold non-inculsive value for this range.
+    * `lte` - (Optional) Indicates the upper threshold inclusive value for this range.
+    * `color` - (Required) The color range to use. Must be either gray, blue, navy, orange, yellow, magenta, purple, violet, lilac, green, aquamarine. ![Colors](https://github.com/Yelp/terraform-provider-signalform/raw/master/docs/resources/colors.png)
 * `unit_prefix` - (Optional) Must be `"Metric"` or `"Binary"`. `"Metric"` by default.
 * `max_delay - (Optional) How long (in seconds) to wait for late datapoints
 * `refresh_interval` - (Optional) How often (in seconds) to refresh the value.

--- a/src/terraform-provider-signalform/signalform/heatmap_chart.go
+++ b/src/terraform-provider-signalform/signalform/heatmap_chart.go
@@ -8,20 +8,6 @@ import (
 	"strings"
 )
 
-var ChartColors = map[string]string{
-	"gray":       "#999999",
-	"blue":       "#0077c2",
-	"navy":       "#6CA2B7",
-	"orange":     "#b04600",
-	"yellow":     "#e5b312",
-	"magenta":    "#bd468d",
-	"purple":     "#e9008a",
-	"violet":     "#876ffe",
-	"lilac":      "#a747ff",
-	"green":      "#05ce00",
-	"aquamarine": "#0dba8f",
-}
-
 func heatmapChartResource() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -126,21 +112,38 @@ func heatmapChartResource() *schema.Resource {
 			"color_scale": &schema.Schema{
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "Values for each color in the range. Example: { thresholds : [80, 60, 40, 0], inverted : true }",
+				Description: "Single color range including both the color to display for that range and the borders of the range",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"thresholds": &schema.Schema{
-							Type:        schema.TypeList,
-							Required:    true,
-							Elem:        &schema.Schema{Type: schema.TypeFloat},
-							MaxItems:    4,
-							Description: "The thresholds to set for the color range being used. Values (at most 4) must be in descending order",
-						},
-						"inverted": &schema.Schema{
-							Type:        schema.TypeBool,
+						"gt": &schema.Schema{
+							Type:        schema.TypeFloat,
 							Optional:    true,
-							Default:     false,
-							Description: "(false by default) If false or omitted, values are red if they are above the highest specified value. If true, values are red if they are below the lowest specified value",
+							Default:     math.MaxFloat32,
+							Description: "Indicates the lower threshold non-inclusive value for this range",
+						},
+						"gte": &schema.Schema{
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Default:     math.MaxFloat32,
+							Description: "Indicates the lower threshold inclusive value for this range",
+						},
+						"lt": &schema.Schema{
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Default:     math.MaxFloat32,
+							Description: "Indicates the upper threshold non-inculsive value for this range",
+						},
+						"lte": &schema.Schema{
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Default:     math.MaxFloat32,
+							Description: "Indicates the upper threshold inclusive value for this range",
+						},
+						"color": &schema.Schema{
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The color to use. Must be either \"gray\", \"blue\", \"navy\", \"orange\", \"yellow\", \"magenta\", \"purple\", \"violet\", \"lilac\", \"green\", \"aquamarine\"",
+							ValidateFunc: validateHeatmapChartColor,
 						},
 					},
 				},
@@ -236,7 +239,7 @@ func getHeatmapOptionsChart(d *schema.ResourceData) map[string]interface{} {
 		viz["colorRange"] = colorRangeOptions
 	} else if colorScaleOptions := getColorScaleOptions(d); len(colorScaleOptions) > 0 {
 		viz["colorBy"] = "Scale"
-		viz["colorScale"] = colorScaleOptions
+		viz["colorScale2"] = colorScaleOptions
 	}
 
 	viz["timestampHidden"] = d.Get("hide_timestamp").(bool)

--- a/src/terraform-provider-signalform/signalform/single_value_chart.go
+++ b/src/terraform-provider-signalform/signalform/single_value_chart.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
+	"math"
 )
 
 func singleValueChartResource() *schema.Resource {
@@ -87,21 +88,38 @@ func singleValueChartResource() *schema.Resource {
 			"color_scale": &schema.Schema{
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "Values for each color in the range. Example: { thresholds : [80, 60, 40, 0], inverted : true }",
+				Description: "Single color range including both the color to display for that range and the borders of the range",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"thresholds": &schema.Schema{
-							Type:        schema.TypeList,
-							Required:    true,
-							Elem:        &schema.Schema{Type: schema.TypeFloat},
-							MaxItems:    4,
-							Description: "The thresholds to set for the color range being used. Values (at most 4) must be in descending order",
-						},
-						"inverted": &schema.Schema{
-							Type:        schema.TypeBool,
+						"gt": &schema.Schema{
+							Type:        schema.TypeFloat,
 							Optional:    true,
-							Default:     false,
-							Description: "(false by default) If false or omitted, values are red if they are above the highest specified value. If true, values are red if they are below the lowest specified value",
+							Default:     math.MaxFloat32,
+							Description: "Indicates the lower threshold non-inclusive value for this range",
+						},
+						"gte": &schema.Schema{
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Default:     math.MaxFloat32,
+							Description: "Indicates the lower threshold inclusive value for this range",
+						},
+						"lt": &schema.Schema{
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Default:     math.MaxFloat32,
+							Description: "Indicates the upper threshold non-inculsive value for this range",
+						},
+						"lte": &schema.Schema{
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Default:     math.MaxFloat32,
+							Description: "Indicates the upper threshold inclusive value for this range",
+						},
+						"color": &schema.Schema{
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The color to use. Must be either \"gray\", \"blue\", \"navy\", \"orange\", \"yellow\", \"magenta\", \"purple\", \"violet\", \"lilac\", \"green\", \"aquamarine\"",
+							ValidateFunc: validateHeatmapChartColor,
 						},
 					},
 				},


### PR DESCRIPTION
SignalFX recently implemented custom colors on a heatmap!

![5022296158765056](https://user-images.githubusercontent.com/10674587/35554131-6f836578-054f-11e8-929e-35cb8b744658.png)

This is options.colorScale2 in https://developers.signalfx.com/v2/reference#section-payload

We can replace the one already there under the name options.colorScale, since never used by our users and also less powerful than this one. 