### PR TITLE
Fixing ffi version before installation of fpm.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,6 +21,7 @@ ENV GOPATH /go
 RUN mkdir /go
 ENV RUBYOPT="-KU -E utf-8:utf-8"
 RUN gem install json -v 1.8.3 --no-rdoc --no-ri
+RUN gem install ffi --no-rdoc --no-ri -v 1.9.18
 RUN gem install fpm --no-rdoc --no-ri -v 1.4.0
 
 RUN git clone https://github.com/hashicorp/terraform.git /go/src/github.com/hashicorp/terraform && \


### PR DESCRIPTION
**Summary**
Last stable build used v1.9.18 for ffi on fpm. New build however started
using v1.9.21 for ffi. Fix this by installing the stable gem for ffi
before fpm.

**Reference**
[Stable Build](https://travis-ci.org/Yelp/terraform-provider-signalform/builds/336215106)
[Unstable Build](https://travis-ci.org/Yelp/terraform-provider-signalform/builds/338163465)

