### PR TITLE
Add support for replaceOnly to dashboards

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -60,6 +60,7 @@ The following arguments are supported in the resource block:
     * `value_required` - (Optional) Determines whether a value is required for this variable (and therefore whether it will be possible to view this dashboard without this filter applied). `false` by default.
     * `values_suggested` - (Optional) A list of strings of suggested values for this variable; these suggestions will receive priority when values are autosuggested for this variable.
     * `restricted_suggestions` - (Optional) If `true`, this variable may only be set to the values listed in `values_suggested` and only these values will appear in autosuggestion menus. `false` by default.
+    * `replace_only` - (Optional) If `true`, this variable will only apply to charts that have a filter for the property.
 * `chart` - (Optional) Chart ID and layout information for the charts in the dashboard.
     * `chart_id` - (Required) ID of the chart to display.
     * `width` - (Optional) How many columns (out of a total of 12) the chart should take up (between `1` and `12`). `12` by default.

--- a/src/terraform-provider-signalform/signalform/dashboard.go
+++ b/src/terraform-provider-signalform/signalform/dashboard.go
@@ -3,8 +3,9 @@ package signalform
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 const (
@@ -236,6 +237,12 @@ func dashboardResource() *schema.Resource {
 							Default:     false,
 							Description: "If true, this variable may only be set to the values listed in preferredSuggestions. and only these values will appear in autosuggestion menus. false by default",
 						},
+						"replace_only": &schema.Schema{
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "If true, this variable will only apply to charts with a filter on the named property.",
+						},
 					},
 				},
 			},
@@ -437,6 +444,8 @@ func getDashboardVariables(d *schema.ResourceData) []map[string]interface{} {
 			}
 		}
 		item["restricted"] = variable["restricted_suggestions"].(bool)
+
+		item["replaceOnly"] = variable["replace_only"].(bool)
 
 		vars_list[i] = item
 	}


### PR DESCRIPTION
I was looking for the API equivalent to this, and SignalFX support confirms it's replaceOnly:

https://docs.signalfx.com/en/latest/dashboards/dashboard-filter-dynamic.html#how-variables-apply