### PR TITLE
Add support for labeled watermark lines

### DIFF
--- a/docs/resources/time_chart.md
+++ b/docs/resources/time_chart.md
@@ -61,13 +61,17 @@ The following arguments are supported in the resource block:
     * `min_value` - (Optional) The minimum value for the left axis.
     * `max_value` - (Optional) The maximum value for the left axis.
     * `high_watermark` - (Optional) A line to draw as a high watermark.
+    * `high_watermark_label` - (Optional) A label to attach to the high watermark line.
     * `low_watermark`  - (Optional) A line to draw as a low watermark.
+    * `low_watermark_label` - (Optional) A label to attach to the low watermark line.
 * `axis_right` - (Optional) Set of axis options.
     * `label` - (Optional) Label of the right axis.
     * `min_value` - (Optional) The minimum value for the right axis.
     * `max_value` - (Optional) The maximum value for the right axis.
     * `high_watermark` - (Optional) A line to draw as a high watermark.
+    * `high_watermark_label` - (Optional) A label to attach to the high watermark line.
     * `low_watermark`  - (Optional) A line to draw as a low watermark.
+    * `low_watermark_label` - (Optional) A label to attach to the low watermark line.
 * `viz_options` - (Optional) Plot-level customization options, associated with a publish statement.
     * `label` - (Required) Label used in the publish statement that displays the plot (metric time series data) you want to customize.
     * `color` - (Optional) Color to use : gray, blue, azure, navy, brown, orange, yellow, iris, magenta, pink, purple, violet, lilac, emerald, green, aquamarine. ![Colors](https://github.com/Yelp/terraform-provider-signalform/raw/master/docs/resources/colors.png)

--- a/src/terraform-provider-signalform/signalform/time_chart.go
+++ b/src/terraform-provider-signalform/signalform/time_chart.go
@@ -139,11 +139,21 @@ func timeChartResource() *schema.Resource {
 							Default:     math.MaxFloat32,
 							Description: "A line to draw as a high watermark",
 						},
+						"high_watermark_label": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A label to attach to the high watermark line",
+						},
 						"low_watermark": &schema.Schema{
 							Type:        schema.TypeFloat,
 							Optional:    true,
 							Default:     -math.MaxFloat32,
 							Description: "A line to draw as a low watermark",
+						},
+						"low_watermark_label": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A label to attach to the low watermark line",
 						},
 					},
 				},
@@ -176,11 +186,21 @@ func timeChartResource() *schema.Resource {
 							Default:     math.MaxFloat32,
 							Description: "A line to draw as a high watermark",
 						},
+						"high_watermark_label": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A label to attach to the high watermark line",
+						},
 						"low_watermark": &schema.Schema{
 							Type:        schema.TypeFloat,
 							Optional:    true,
 							Default:     -math.MaxFloat32,
 							Description: "A line to draw as a low watermark",
+						},
+						"low_watermark_label": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A label to attach to the low watermark line",
 						},
 					},
 				},
@@ -374,12 +394,18 @@ func getSingleAxisOptions(axisOpt map[string]interface{}) map[string]interface{}
 			item["highWatermark"] = val.(float64)
 		}
 	}
+	if val, ok := axisOpt["high_watermark_label"]; ok {
+		item["highWatermarkLabel"] = val.(string)
+	}
 	if val, ok := axisOpt["low_watermark"]; ok {
 		if val.(float64) == -math.MaxFloat32 {
 			item["lowWatermark"] = nil
 		} else {
 			item["lowWatermark"] = val.(float64)
 		}
+	}
+	if val, ok := axisOpt["low_watermark_label"]; ok {
+		item["lowWatermarkLabel"] = val.(string)
 	}
 	return item
 }


### PR DESCRIPTION
Pretty much does what it says on the tin. (This parameter was added fairly recently, but it is documented in the signalfx API reference if you want to know more about it.) I didn't notice any tests for the affected functions, but if there are tests I should be updating, please point them out to me and I'll fix them.