### PR TITLE
Allow detector rules to notify a team

### DIFF
--- a/src/terraform-provider-signalform/signalform/detector.go
+++ b/src/terraform-provider-signalform/signalform/detector.go
@@ -287,6 +287,8 @@ func getNotifications(tf_notifications []interface{}) []map[string]interface{} {
 		} else if vars[0] == "Webhook" {
 			item["secret"] = vars[1]
 			item["url"] = vars[2]
+		} else if vars[0] == "Team" || vars[0] == "TeamEmail" {
+			item["team"] = vars[1]
 		}
 
 		notifications_list[i] = item


### PR DESCRIPTION
Another PR that does what it says on the tin. It adds support for the `rules[x].notifications[y].team` parameter described [here](https://developers.signalfx.com/reference#create-detector).