### PR TITLE
Add teams support to dashboard groups

### DIFF
--- a/docs/resources/dashboard_group.md
+++ b/docs/resources/dashboard_group.md
@@ -20,4 +20,5 @@ The following arguments are supported in the resource block:
 
 * `name` - (Required) Name of the dashboard group.
 * `description` - (Required) Description of the dashboard group.
+* `teams` - (Optional) Team IDs to associate the dashboard group to.
 * `synced` - (Optional) Whether the resource in SignalForm and SignalFx are identical or not. Used internally for syncing, you don not need to specify it. Whenever you see a change to this field in the plan, it means that your resource has been changed from the UI and Terraform is now going to re-sync it back to what is in your configuration.

--- a/src/terraform-provider-signalform/signalform/dashboard_group.go
+++ b/src/terraform-provider-signalform/signalform/dashboard_group.go
@@ -3,6 +3,7 @@ package signalform
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -32,6 +33,12 @@ func dashboardGroupResource() *schema.Resource {
 				Optional:    true,
 				Description: "Description of the dashboard group",
 			},
+			"teams": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Team IDs to associate the dashboard group to",
+			},
 		},
 
 		Create: dashboardgroupCreate,
@@ -50,6 +57,14 @@ func getPayloadDashboardGroup(d *schema.ResourceData) ([]byte, error) {
 		"description": d.Get("description").(string),
 		// We are not keeping track of this because it's already done in the dashboard resource.
 		"dashboards": make([]string, 0),
+	}
+
+	if val, ok := d.GetOk("teams"); ok {
+		teams := []string{}
+		for _, team := range val.([]interface{}) {
+			teams = append(teams, team.(string))
+		}
+		payload["teams"] = teams
 	}
 
 	return json.Marshal(payload)


### PR DESCRIPTION
Simple change to copy the support from detectors over to dashboard groups, where they're also supported in the API.