### PR TITLE
Add logging of dashboard create and update payloads

### DIFF
--- a/src/terraform-provider-signalform/signalform/dashboard.go
+++ b/src/terraform-provider-signalform/signalform/dashboard.go
@@ -3,6 +3,7 @@ package signalform
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -474,7 +475,7 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-
+	log.Printf("[SignalForm] Dashboard Create Payload: %s", string(payload))
 	return resourceCreate(DASHBOARD_API_URL, config.AuthToken, payload, d)
 }
 
@@ -492,7 +493,7 @@ func dashboardUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	url := fmt.Sprintf("%s/%s", DASHBOARD_API_URL, d.Id())
-
+	log.Printf("[SignalForm] Dashboard Update Payload: %s", string(payload))
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 


### PR DESCRIPTION
# Summary

Adds logging of dashboard create and update payloads.

# Motivation

When debugging new features I keep hacking in weird ways to view the payload. This — when used with TF_LOG — allows easy inspection of the body!

# Notes

I'm following convention used in the Datadog provider. It seems this should really be a log level, but [log levels in terraform seem broken anyway](https://github.com/hashicorp/terraform/issues/6468).

Let me know if you'd like to see this in a different shape!