### PR TITLE
Add applyIfExists for dashboard vars/filters

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -52,6 +52,7 @@ The following arguments are supported in the resource block:
     * `property` - (Required) A metric time series dimension or property name.
     * `not` - (Optional) Whether this filter should be a not filter. `false` by default.
     * `values` - (Required) List of of strings (which will be treated as an OR filter on the property).
+    * `apply_if_exist` - (Optional) If true, this filter will also match data that doesn't have this property at all.
 * `variable` - (Optional) Dashboard variable to apply to each chart in the dashboard.
     * `property` - (Required) A metric time series dimension or property name.
     * `alias` - (Required) An alias for the dashboard variable. This text will appear as the label for the dropdown field on the dashboard.
@@ -61,6 +62,7 @@ The following arguments are supported in the resource block:
     * `values_suggested` - (Optional) A list of strings of suggested values for this variable; these suggestions will receive priority when values are autosuggested for this variable.
     * `restricted_suggestions` - (Optional) If `true`, this variable may only be set to the values listed in `values_suggested` and only these values will appear in autosuggestion menus. `false` by default.
     * `replace_only` - (Optional) If `true`, this variable will only apply to charts that have a filter for the property.
+    * `apply_if_exist` - (Optional) If true, this variable will also match data that doesn't have this property at all.
 * `chart` - (Optional) Chart ID and layout information for the charts in the dashboard.
     * `chart_id` - (Required) ID of the chart to display.
     * `width` - (Optional) How many columns (out of a total of 12) the chart should take up (between `1` and `12`). `12` by default.

--- a/src/terraform-provider-signalform/signalform/dashboard.go
+++ b/src/terraform-provider-signalform/signalform/dashboard.go
@@ -243,6 +243,12 @@ func dashboardResource() *schema.Resource {
 							Default:     false,
 							Description: "If true, this variable will only apply to charts with a filter on the named property.",
 						},
+						"apply_if_exist": &schema.Schema{
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "If true, this variable will also match data that does not have the specified property",
+						},
 					},
 				},
 			},
@@ -268,6 +274,12 @@ func dashboardResource() *schema.Resource {
 							Required:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: "List of strings (which will be treated as an OR filter on the property)",
+						},
+						"apply_if_exist": &schema.Schema{
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "If true, this filter will also match data that does not have the specified property",
 						},
 					},
 				},
@@ -444,6 +456,7 @@ func getDashboardVariables(d *schema.ResourceData) []map[string]interface{} {
 			}
 		}
 		item["restricted"] = variable["restricted_suggestions"].(bool)
+		item["applyIfExists"] = variable["apply_if_exist"].(bool)
 
 		item["replaceOnly"] = variable["replace_only"].(bool)
 
@@ -461,6 +474,7 @@ func getDashboardFilters(d *schema.ResourceData) []map[string]interface{} {
 
 		item["property"] = filter["property"].(string)
 		item["NOT"] = filter["negated"].(bool)
+		item["applyIfExists"] = filter["apply_if_exist"].(bool)
 		item["value"] = filter["values"].(*schema.Set).List()
 
 		filter_list[i] = item


### PR DESCRIPTION
This API parameter is equivalent to `Allow data matching the filter condition or missing <property>` on https://docs.signalfx.com/en/latest/dashboards/dashboard-filter-dynamic.html.