### PR TITLE
Fix colorscale to use the correct colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ crash.log
 *.lock
 *.swp
 *.swo
+deps

--- a/Makefile
+++ b/Makefile
@@ -21,19 +21,20 @@ all: fmt .git/hooks/pre-commit test build itest_trusty itest_xenial
 fmt:
 	go fmt ./...
 
-.PHONY: deps
 deps:
 	@echo Getting dependencies...
 	@go get github.com/Masterminds/glide
 	@cd src/github.com/Masterminds/glide && git checkout --quiet v0.12.3
 	@go build -o bin/glide github.com/Masterminds/glide/
 	@cd $(BASE) && $(GLIDE) install
+	@touch deps
 
 .PHONY: clean
 clean:
 	rm -rf bin
 	rm -rf pkg
 	make -C build clean
+	rm -f deps
 
 .PHONY: build
 build: test

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ binary:
 
 .PHONY: test
 test: deps
-	cd $(BASE) && go test -v $$(glide novendor)
+	cd $(BASE) && go test -v $$(glide novendor) ${TEST_OPTS}
 
 .PHONY: changelog
 changelog:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:trusty
 MAINTAINER team-metrics <team-metrics@yelp.com>
 
 ENV GO_VERSION=1.9
-ENV TF_VERSION=0.11.7
+ENV TF_VERSION=0.10.7
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     wget \

--- a/build/Makefile
+++ b/build/Makefile
@@ -9,8 +9,8 @@ else
 endif
 ORG ?= default
 
-VERSION := 3.0.0
-TF_VERSION := 0.11
+VERSION := 2.7.0
+TF_VERSION := 0.10
 ITERATION := $(ORG)$(REAL_BUILD_NUMBER)
 
 TF_PATH ?= /nail/opt/terraform-$(TF_VERSION)

--- a/build/Makefile
+++ b/build/Makefile
@@ -9,7 +9,7 @@ else
 endif
 ORG ?= default
 
-VERSION := 2.7.0
+VERSION := 2.7.1
 TF_VERSION := 0.10
 ITERATION := $(ORG)$(REAL_BUILD_NUMBER)
 

--- a/build/changelog
+++ b/build/changelog
@@ -1,3 +1,9 @@
+terraform-provider-signalform (2.7.1) trusty; urgency=medium
+
+  * use correct colors in colorscale
+
+ -- Timothy Mower <tmower@yelp.com>  Fri, 06 Jul 2018 03:36:47 -0700
+
 terraform-provider-signalform (2.7.0) trusty; urgency=low
 
   * Added teams to dashboard groups.

--- a/build/changelog
+++ b/build/changelog
@@ -1,9 +1,3 @@
-terraform-provider-signalform (3.0.0) trusty; urgency=low
-
-  * Building against terraform 0.11
-
- -- Tim Mower <tmower@yelp.com>  Tue, 12 Jun 2018 10:07:28 -0700
-
 terraform-provider-signalform (2.7.0) trusty; urgency=low
 
   * Added teams to dashboard groups.

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,24 @@ To make a new release:
 ## Contributing
 Everyone is encouraged to contribute to `terraform-provider-signalform`. You can contribute by forking the GitHub repo and making a pull request or opening an issue.
 
+## Running tests
+
+To run the tests, run `make test`
+
+To pass options to the test, e.g to target a specific test, pass the TEST_OPTS
+option to the make task - e.g
+
+```
+make test TEST_OPTS='-test.run TestSendRequestSuccess'
+```
+
+To make the tests run faster, you can run
+
+```
+make test TEST_OPTS='-i'
+```
+
+Subsequent make test commands should be quicker
 
 ## FAQ
 

--- a/src/terraform-provider-signalform/glide.yaml
+++ b/src/terraform-provider-signalform/glide.yaml
@@ -4,7 +4,7 @@ import:
   subpackages:
   - netrc
 - package: github.com/hashicorp/terraform
-  version: 0.11.7
+  version: 0.10.7
   subpackages:
   - helper/hashcode
   - helper/schema

--- a/src/terraform-provider-signalform/signalform/heatmap_chart.go
+++ b/src/terraform-provider-signalform/signalform/heatmap_chart.go
@@ -3,9 +3,10 @@ package signalform
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"math"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func heatmapChartResource() *schema.Resource {

--- a/src/terraform-provider-signalform/signalform/heatmap_chart.go
+++ b/src/terraform-provider-signalform/signalform/heatmap_chart.go
@@ -199,7 +199,12 @@ func getHeatmapColorRangeOptions(d *schema.ResourceData) map[string]interface{} 
 			}
 		}
 		color := options["color"].(string)
-		item["color"] = ChartColors[color]
+		for _, colorStruct := range ChartColorsSlice {
+			if color == colorStruct.name {
+				item["color"] = colorStruct.name
+				break
+			}
+		}
 	}
 	return item
 }
@@ -287,11 +292,15 @@ func heatmapchartDelete(d *schema.ResourceData, meta interface{}) error {
 */
 func validateHeatmapChartColor(v interface{}, k string) (we []string, errors []error) {
 	value := v.(string)
-	if _, ok := ChartColors[value]; !ok {
-		keys := make([]string, 0, len(ChartColors))
-		for k := range ChartColors {
-			keys = append(keys, k)
+	keys := make([]string, 0, len(ChartColorsSlice))
+	found := false
+	for _, item := range ChartColorsSlice {
+		if value == item.name {
+			found = true
 		}
+		keys = append(keys, item.name)
+	}
+	if !found {
 		joinedColors := strings.Join(keys, ",")
 		errors = append(errors, fmt.Errorf("%s not allowed; must be either %s", value, joinedColors))
 	}

--- a/src/terraform-provider-signalform/signalform/util.go
+++ b/src/terraform-provider-signalform/signalform/util.go
@@ -21,21 +21,26 @@ const (
 	CHART_URL     = "https://app.signalfx.com/#/chart/<id>"
 )
 
-var ChartColors = map[string]string{
-	"gray":        "#999999",
-	"blue":        "#0077c2",
-	"navy":        "#6CA2B7",
-	"orange":      "#b04600",
-	"yellow":      "#e5b312",
-	"magenta":     "#bd468d",
-	"purple":      "#e9008a",
-	"violet":      "#876ffe",
-	"lilac":       "#a747ff",
-	"green":       "#05ce00",
-	"aquamarine":  "#0dba8f",
-	"red":         "#ea1849",
-	"light_green": "#acef7f",
-	"dark_green":  "#6bd37e",
+type chartColor struct {
+	name string
+	hex  string
+}
+
+var ChartColorsSlice = []chartColor{
+	{"gray", "#999999"},
+	{"blue", "#0077c2"},
+	{"navy", "#6CA2B7"},
+	{"orange", "#b04600"},
+	{"yellow", "#e5b312"},
+	{"magenta", "#bd468d"},
+	{"purple", "#e9008a"},
+	{"violet", "#876ffe"},
+	{"lilac", "#a747ff"},
+	{"green", "#05ce00"},
+	{"aquamarine", "#0dba8f"},
+	{"red", "#ea1849"},
+	{"light_green", "#acef7f"},
+	{"dark_green", "#6bd37e"},
 }
 
 /*
@@ -114,11 +119,11 @@ func getColorScaleOptionsFromSlice(colorScale []interface{}) []interface{} {
 			options["lte"] = scale["lte"].(float64)
 		}
 		paletteIndex := 0
-		for colorName, _ := range ChartColors {
-			if colorName == scale["color"].(string) {
+		for index, thing := range ChartColorsSlice {
+			if scale["color"] == thing.name {
+				paletteIndex = index
 				break
 			}
-			paletteIndex++
 		}
 		options["paletteIndex"] = paletteIndex
 		item[i] = options

--- a/src/terraform-provider-signalform/signalform/util.go
+++ b/src/terraform-provider-signalform/signalform/util.go
@@ -90,6 +90,10 @@ func validateSortBy(v interface{}, k string) (we []string, errors []error) {
 */
 func getColorScaleOptions(d *schema.ResourceData) []interface{} {
 	colorScale := d.Get("color_scale").(*schema.Set).List()
+	return getColorScaleOptionsFromSlice(colorScale)
+}
+
+func getColorScaleOptionsFromSlice(colorScale []interface{}) []interface{} {
 	item := make([]interface{}, len(colorScale))
 	if len(colorScale) == 0 {
 		return item

--- a/src/terraform-provider-signalform/signalform/util.go
+++ b/src/terraform-provider-signalform/signalform/util.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"io/ioutil"
 	"math"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 const (

--- a/src/terraform-provider-signalform/signalform/util_test.go
+++ b/src/terraform-provider-signalform/signalform/util_test.go
@@ -98,3 +98,21 @@ func TestSanitizeProgramText(t *testing.T) {
 	sane_text := "previous = data('statmonster.inbound_lines',filter('source_region','${var.clusters_no_uswest2[count.index]}')).timeshift('2m').sum()\nsignal = data('statmonster.inbo    und_lines',filter('source_region','${var.clusters_no_uswest2[count.index]}')).sum()\ndetect('Low number of log lines', when(signal < (previous * 0.50), '2m', 0.90))"
 	assert.Equal(t, sane_text, sanitizeProgramText(text))
 }
+
+func TestCorrectColorValue(t *testing.T) {
+	options := map[string](interface{}){
+		"color": "magenta",
+		"gt":    0.0,
+		"gte":   0.0,
+		"lt":    0.0,
+		"lte":   0.0,
+	}
+	colorscale := []interface{}{options}
+	retm := getColorScaleOptionsFromSlice(colorscale)
+
+	ret := retm[0].(map[string]interface{})
+	// should be 5 - https://developers.signalfx.com/reference#section-color-palette
+	fmt.Printf("%+v", ret)
+	assert.Equal(t, 5, ret["paletteIndex"])
+
+}

--- a/src/terraform-provider-signalform/signalform/util_test.go
+++ b/src/terraform-provider-signalform/signalform/util_test.go
@@ -2,10 +2,11 @@ package signalform
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSendRequestSuccess(t *testing.T) {


### PR DESCRIPTION
I've put more detail in the commit messages, but to try and summarize, i found the colorScale option as used by heatmap chart was returning the incorrect colors. To see what was going on I tried to write a unit test to test the behaviour, but to avoid having to deal with terraform internals i've had to refactor the code slightly. I'm not sure if there is a more idiomatic go way of testing this function.

In the fix i've changed the data structure from a map to a slice of structs, which i'd like some feedback on if its the right data structure to be using

To test this fix i've had to drop the terraform version back to 0.10, as we dont have a proper package of terraform 0.11 yet - i've built this on a devbox and tested the `webs/charts` directory of terraform is now at least using consistent colors for the heatmap charts, although I still dont see the full behaviour I want with the provider I think this is at least a step in the right direction.