### PR TITLE
Fixed broken link to dashboard_group.md in documentation 

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -2,7 +2,7 @@
 
 A dashboard is a curated collection of specific charts and supports dimensional [filters](http://docs.signalfx.com/en/latest/dashboards/dashboard-filter-dynamic.html#filter-dashboard-charts), [dashboard variables](http://docs.signalfx.com/en/latest/dashboards/dashboard-filter-dynamic.html#dashboard-variables) and [time range](http://docs.signalfx.com/en/latest/_sidebars-and-includes/using-time-range-selector.html#time-range-selector) options. These options are applied to all charts in the dashboard, providing a consistent view of the data displayed in that dashboard. This also means that when you open a chart to drill down for more details, you are viewing the same data that is visible in the dashboard view.
 
-**NOTE:** Since every dashboard is included in a [dashboard group](dashbord_group.md) (SignalFx collection of dashboards), you need to create that first and reference it as shown in the example.
+**NOTE:** Since every dashboard is included in a [dashboard group](dashboard_group.md) (SignalFx collection of dashboards), you need to create that first and reference it as shown in the example.
 
 
 ## Example Usage


### PR DESCRIPTION
In the [`dashboard`](https://yelp.github.io/terraform-provider-signalform/resources/dashboard.html) resource page, one of the first things that the documentation instructs you to do is create a [`dashboard_group`](https://yelp.github.io/terraform-provider-signalform/resources/dashboard_group.html). It also provides a link to the relevant documentation page. This link was broken due to a misspelling in the link. The issue was a missing "a" character in the file name.

This tiny PR adds the missing character and fixes the link to correctly point to the [`dashboard_group`](https://yelp.github.io/terraform-provider-signalform/resources/dashboard_group.html) documentation. 