### PR TITLE
List severities in order of decreasing severity

### DIFF
--- a/docs/resources/detector.md
+++ b/docs/resources/detector.md
@@ -54,7 +54,7 @@ variable "clusters" {
 * `teams` - (Optional) Team IDs to associcate the detector to.
 * `rule` - (Required) Set of rules used for alerting.
     * `detect_label` - (Required) A detect label which matches a detect label within `program_text`.
-    * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Warning"`, `"Major"`, `"Minor"`, `"Info"`.
+    * `severity` - (Required) The severity of the rule, must be one of: `"Critical"`, `"Major"`, `"Minor"`, `"Warning"`, `"Info"`.
     * `disabled` - (Optional) When true, notifications and events will not be generated for the detect label. `false` by default.
     * `notifications` - (Optional) List of strings specifying where notifications will be sent when an incident occurs. See <https://developers.signalfx.com/v2/reference#section-notifications> for more info.
     * `parameterized_body` - (Optional) Custom notification message body when an alert is triggered. See <https://developers.signalfx.com/v2/reference#section-custom-notification-messages> for more info.

--- a/src/terraform-provider-signalform/signalform/detector.go
+++ b/src/terraform-provider-signalform/signalform/detector.go
@@ -374,7 +374,7 @@ func resourceRuleHash(v interface{}) int {
 */
 func validateSeverity(v interface{}, k string) (we []string, errors []error) {
 	value := v.(string)
-	allowedWords := []string{"Critical", "Warning", "Major", "Minor", "Info"}
+	allowedWords := []string{"Critical", "Major", "Minor", "Warning", "Info"}
 	for _, word := range allowedWords {
 		if value == word {
 			return


### PR DESCRIPTION
The current ordering (putting Warning before Major) is confusing because Warning is actually less severe.

From https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html, detector severities are listed in this order:
> SignalFx has 5 severity labels: Critical, Major, Minor, Warning and Info.