### PR TITLE
Build for Terraform 0.12

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 MAINTAINER Yelp <darwin@yelp.dog>
 
 ENV GO_VERSION=1.11
-ENV TF_VERSION=0.10.7
+ENV TF_VERSION=0.12.1
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -yq \
     build-essential \

--- a/build/Makefile
+++ b/build/Makefile
@@ -9,8 +9,8 @@ else
 endif
 ORG ?= default
 
-VERSION := 2.9.0
-TF_VERSION := 0.10
+VERSION := 2.10.0
+TF_VERSION := 0.12
 ITERATION := $(ORG)$(REAL_BUILD_NUMBER)
 
 TF_PATH ?= /nail/opt/terraform-$(TF_VERSION)


### PR DESCRIPTION
This should be a simple case of just incrementing the version as we pull down the code dynamically at build time.

`make itest_xenial` builds the package as expected.