### PR TITLE
Add optional debug output when run with TF_LOG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ clean:
 	rm -rf pkg
 	make -C build clean
 	rm -f deps
+	rm -rf src/terraform-provider-signalform/vendor
 
 .PHONY: build
 build: test


### PR DESCRIPTION
While investigating issues with SignalForm I've built it locally with some useful logging output for determining where the config for SignalFX is being provided / detected by the provider. I think it'd be helpful to have it as part of the provider rather than just my own debug usage.