### PR TITLE
Fix the error message about bad config

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -9,7 +9,7 @@ else
 endif
 ORG ?= default
 
-VERSION := 2.10.0
+VERSION := 2.11.0
 TF_VERSION := 0.12
 ITERATION := $(ORG)$(REAL_BUILD_NUMBER)
 

--- a/build/changelog
+++ b/build/changelog
@@ -1,3 +1,9 @@
+terraform-provider-signalform (2.11.0) xenial; urgency=low
+
+  * Update to fix unhelpful error message
+
+ -- Tomas Doran <tdoran@yelp.com>  Wed, 26 Feb 2020 14:01:00 -0800
+
 terraform-provider-signalform (2.9.0) xenial; urgency=low
 
   * Update packaging to use xenial and go 1.11

--- a/src/terraform-provider-signalform/signalform/provider.go
+++ b/src/terraform-provider-signalform/signalform/provider.go
@@ -97,7 +97,7 @@ func readConfigFile(configPath string, config *signalformConfig) error {
 	}
 	err = json.Unmarshal(configFile, config)
 	if err != nil {
-		return fmt.Errorf("Failed to parse config file. %s", err.Error())
+		return fmt.Errorf("Failed to parse config file (%s): %s", configPath, err.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
It would make debugging much easier if the error message told you *which* config file was bad.